### PR TITLE
Omit pin config in SPI.begin() for ESP boards

### DIFF
--- a/src/Screen_EPD_EXT3.cpp
+++ b/src/Screen_EPD_EXT3.cpp
@@ -315,7 +315,7 @@ void Screen_EPD_EXT3::begin()
 #elif defined(ARDUINO_ARCH_ESP32)
 
     // Board ESP32-Pico-DevKitM-2 crashes if pins are not specified.
-    SPI.begin(14, 12, 13); // SCK MISO MOSI
+    SPI.begin();
 
 #else
 


### PR DESCRIPTION
Omit pin configurations. They overwrite board settings in main.

### Motivation
Defining pins in `SPI.begin()` renders the library useless, when using a devkit v1. It should not be th lbraries concearn, if someone provides a bad `pins_t` config so that the ESP32-Pico-DevKitM-2 crashes. 

### Change description
Initializing SPI with default settings.

### Other information
Tested with ESP32 Devkit V1 and wiring according to the official documentation.

### Reviewer checklist
* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)