### PR TITLE
Added missing semicolon

### DIFF
--- a/src/hV_HAL_Peripherals.cpp
+++ b/src/hV_HAL_Peripherals.cpp
@@ -237,7 +237,7 @@ void hV_HAL_SPI3_begin()
 #if defined(ARDUINO_XIAO_ESP32C3)
 
     // Board Xiao ESP32-C3 crashes if pins are not specified.
-    hV_HAL_SPI3_define(8, 9) // SCK SDA
+    hV_HAL_SPI3_define(8, 9); // SCK SDA
 
 #elif defined(ARDUINO_ESP32_PICO)
 


### PR DESCRIPTION
### Motivation
Compiling for XIAO ESP32C3 currently fails with the following error due to a missing semicolon:
```
~/Documents/Arduino/libraries/PDLS_EXT3_Basic_Global/src/hV_HAL_Peripherals.cpp: In function 'void hV_HAL_SPI3_begin()':
~/Documents/Arduino/libraries/PDLS_EXT3_Basic_Global/src/hV_HAL_Peripherals.cpp:240:29: error: expected ';' before '}' token
  240 |     hV_HAL_SPI3_define(8, 9) // SCK SDA
      |                             ^
      |                             ;
......
  253 | }
      | ~                            

exit status 1

Compilation error: exit status 1
```

### Change description
Adds a missing semicolon

### Other information
<!-- Any additional information that could help the review process -->

### Reviewer checklist

* [x] PR addresses a single concern.
* [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [x] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)